### PR TITLE
Fail if required sources are not found

### DIFF
--- a/q2d.pro
+++ b/q2d.pro
@@ -10,9 +10,9 @@ picosatDir = "$$OUT_PWD/picosat-960"
 quantorDir = "$$OUT_PWD/quantor-3.2"
 
 !exists($$picosatDir){
-    message(No picosat directory)
+    error(No picosat directory)
 } {
-    message(picosat directory is $$picosatDir)
+    error(picosat directory is $$picosatDir)
 }
 
 


### PR DESCRIPTION
Currently the "xyz not found" messages are only messages. Make them fail the qmake build. They should be errors as long as q2d does not build without the libs
